### PR TITLE
move download to downloaders

### DIFF
--- a/downloaders/aria2crpc.js
+++ b/downloaders/aria2crpc.js
@@ -1,8 +1,11 @@
 const Aria2 = require('aria2')
 const { URL } = require('url')
+const log = require('debug')('dmhy:downloaders:aria2crpc')
 const args = process.argv.slice(2)
 const thread = JSON.parse(args[0])
 const { jsonrpc, dest } = JSON.parse(args[1])
+
+log(args)
 
 const u = new URL(jsonrpc)
 const verify = [

--- a/downloaders/aria2crpc.js
+++ b/downloaders/aria2crpc.js
@@ -1,0 +1,43 @@
+const Aria2 = require('aria2')
+const { URL } = require('url')
+const args = process.argv.slice(2)
+const thread = JSON.parse(args[0])
+const { jsonrpc, dest } = JSON.parse(args[1])
+
+const u = new URL(jsonrpc)
+const verify = [
+  [!u.hostname, 'You must provide hostname'],
+  [u.username && u.username !== 'token', 'Only secret is supported!'],
+  [u.username && !u.password, 'You must provide secret']
+]
+verify.forEach(([cond, msg]) => {
+  if (cond) {
+    console.log(msg)
+    process.exit(1)
+  }
+})
+const client = new Aria2({
+  host: u.hostname,
+  port: u.port || 6800,
+  secure: false,
+  secret: u.password,
+  path: u.pathname
+})
+client.onerror = err => {
+  console.error('aria2c connect error: %o', err)
+}
+const opts = {}
+if (dest) {
+  opts.dir = dest
+}
+client
+  .open()
+  .then(() => client.addUri([thread.link], opts))
+  .then(() => {
+    console.log(`Download ${thread.title}`)
+    client.close()
+  })
+  .catch(() => {
+    console.error(`Failed to download ${thread.title}.`)
+    client.close()
+  })

--- a/downloaders/deluge-console.js
+++ b/downloaders/deluge-console.js
@@ -1,5 +1,5 @@
 const { spawn } = require('child_process')
-const log = require('debug')('dmhy:downloaders:deluge+console')
+const log = require('debug')('dmhy:downloaders:deluge-console')
 
 const args = process.argv.slice(2)
 const thread = JSON.parse(args[0])

--- a/downloaders/deluge-console.js
+++ b/downloaders/deluge-console.js
@@ -1,9 +1,10 @@
 const { spawn } = require('child_process')
-const debug = require('debug')
-const log = debug('dmhy:downloaders:deluge')
+const log = require('debug')('dmhy:downloaders:deluge+console')
 
 const args = process.argv.slice(2)
 const thread = JSON.parse(args[0])
+
+log(args)
 
 const task = spawn('deluge-console', ['add', thread.link])
 log(`start deluge-console on pid ${task.pid}`)

--- a/downloaders/deluge-console.js
+++ b/downloaders/deluge-console.js
@@ -1,0 +1,20 @@
+const { spawn } = require('child_process')
+const debug = require('debug')
+const log = debug('dmhy:downloaders:deluge')
+
+const args = process.argv.slice(2)
+const thread = JSON.parse(args[0])
+
+const task = spawn('deluge-console', ['add', thread.link])
+log(`start deluge-console on pid ${task.pid}`)
+
+task.on('close', code => {
+  if (code === 0) {
+    console.log(`Download ${thread.title}`)
+  } else {
+    console.error(`Failed to download ${thread.title}.`)
+  }
+})
+task.on('error', err => {
+  console.error('Failed to start subprocess. %o', err)
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,17 @@
         "sprintf-js": "1.0.3"
       }
     },
+    "aria2": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aria2/-/aria2-3.0.0.tgz",
+      "integrity": "sha1-M2O5gS/PSqO1YVvso0ok7rdrcs0=",
+      "requires": {
+        "commander": "2.13.0",
+        "node-fetch": "1.7.3",
+        "polygoat": "1.1.4",
+        "ws": "1.1.5"
+      }
+    },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
@@ -351,10 +362,9 @@
       "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -449,6 +459,14 @@
       "integrity": "sha1-hvmrTBAvA3G3KXuSplHVgkvIy3M=",
       "requires": {
         "wcwidth": "1.0.1"
+      }
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.19"
       }
     },
     "entities": {
@@ -562,6 +580,17 @@
       "requires": {
         "debug": "2.6.9",
         "resolve": "1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-module-utils": {
@@ -572,6 +601,17 @@
       "requires": {
         "debug": "2.6.9",
         "pkg-dir": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-import": {
@@ -590,6 +630,17 @@
         "lodash.cond": "4.5.2",
         "minimatch": "3.0.4",
         "read-pkg-up": "2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-node": {
@@ -891,8 +942,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "ignore": {
       "version": "3.3.7",
@@ -1004,6 +1054,11 @@
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "isarray": {
       "version": "1.0.0",
@@ -1202,6 +1257,15 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -1259,6 +1323,11 @@
         "type-check": "0.3.2",
         "wordwrap": "1.0.0"
       }
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -1378,6 +1447,11 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
       "dev": true
+    },
+    "polygoat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/polygoat/-/polygoat-1.1.4.tgz",
+      "integrity": "sha1-Mp+aDRstSkUUniU5Ujxvff2FCl8="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -1707,6 +1781,11 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "ultron": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1759,6 +1838,15 @@
       "dev": true,
       "requires": {
         "mkdirp": "0.5.1"
+      }
+    },
+    "ws": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
+      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
+      "requires": {
+        "options": "0.0.6",
+        "ultron": "1.0.2"
       }
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
     "mocha": "^5.0.1"
   },
   "dependencies": {
+    "aria2": "^3.0.0",
     "axios": "^0.17.1",
     "cheerio": "^1.0.0-rc.2",
     "commander": "^2.13.0",
     "console.table": "^0.10.0",
+    "debug": "^3.1.0",
     "readline-sync": "^1.4.9",
     "semver": "^5.5.0"
   }


### PR DESCRIPTION
這個把下載功能都移到`downloaders`資料夾去了，然後額外支援了`aria2crpc`的功能
不過原本的`aria2c`的指令下載功能我不曉得為什麼一直無法下載...
然後目前還沒使用`detached`，目前的`deluge-console`&`aria2crpc`都不需要用到

範例: `node index.js dl UUA-8 --client aria2crpc --jsonrpc=https://token:MY_TOKEN_OF_ARIA2C@localhost:6800/jsonrpc -d C:\Users\Administrator\temp`


另外有些格式上的更改是 vscode 自己根據`.eslintrc.json`改的...