### PR TITLE
增加 update 的 --all 和基本的 config 實作

### DIFF
--- a/config.js
+++ b/config.js
@@ -11,9 +11,17 @@ class Config {
     this.configfile = configfile
 
     if (!fs.existsSync(this.configfile)) {
-      this.writeConfig(DEFAULT_CONFIG)
+      try {
+        this.writeConfig(DEFAULT_CONFIG)
+      } catch (e) {
+        if (require.main.filename.endsWith('postinstall.js')) {
+          // because postinstall.js require fakedb.js, and fakedb.js require config.js even if ~/dmhy-subscribe not exists
+          // so just ignore it
+          return
+        }
+        throw e
+      }
     }
-
     this.readConfig()
   }
   writeConfig (config = this.config) {

--- a/config.js
+++ b/config.js
@@ -1,0 +1,53 @@
+const os = require('os')
+const fs = require('fs')
+
+const DEFAULT_CONFIG = {
+  client: 'deluge',
+  jsonrpc: ''
+}
+
+class Config {
+  constructor ({ configfile } = { configfile: `${os.homedir()}/.dmhy-subscribe/config.json` }) {
+    this.configfile = configfile
+
+    if (!fs.existsSync(this.configfile)) {
+      this.writeConfig(DEFAULT_CONFIG)
+    }
+
+    this.readConfig()
+  }
+  writeConfig (config = this.config) {
+    fs.writeFileSync(this.configfile, JSON.stringify(config))
+  }
+  readConfig () {
+    this.config = JSON.parse(fs.readFileSync(this.configfile, 'utf8'))
+  }
+  get (path) {
+    return path
+      .replace(/\[([^[\]]*)\]/g, '.$1.')
+      .split('.')
+      .filter(t => t !== '')
+      .reduce((prev, cur) => prev && prev[cur], this.config)
+  }
+  set (path, value) {
+    const paths = path
+      .replace(/\[([^[\]]*)\]/g, '.$1.')
+      .split('.')
+      .filter(t => t !== '')
+    function _set (paths, cur) {
+      const pname = paths.shift()
+      if (paths.length === 0) {
+        cur[pname] = value
+      } else {
+        if (!cur.hasOwnProperty(pname))cur[pname] = {}
+        _set(paths, cur[pname])
+      }
+    }
+    _set(paths, this.config)
+
+    this.writeConfig(this.config)
+  }
+}
+module.exports = new Config()
+exports.Config = Config
+exports.DEFAULT_CONFIG = DEFAULT_CONFIG

--- a/fakedb.js
+++ b/fakedb.js
@@ -6,6 +6,7 @@ const path = require('path')
 const { hash, XSet, systemDownloadsFolder } = require('./utils')
 const compat = require('./compatible-test')
 const { version } = require('./package.json')
+const config = require('./config')
 
 require('console.table')
 
@@ -147,10 +148,11 @@ class Database {
 
   download (thread, { client, destination, jsonrpc } = {}) {
     const dest = destination || systemDownloadsFolder
-    const dclient = client || 'deluge'
+    const dclient = client || config.get('client')
+    const djsonrpc = jsonrpc || config.get('jsonrpc')
 
     const script = path.resolve(`${__dirname}/downloaders/${dclient}.js`)
-    const args = [thread, { dest, jsonrpc }].map(JSON.stringify)
+    const args = [thread, { dest, jsonrpc: djsonrpc }].map(JSON.stringify)
     args.unshift(script)
 
     return new Promise((resolve, reject) => {

--- a/index.js
+++ b/index.js
@@ -181,30 +181,30 @@ program
 
 program
   .command('update [sid...]')
+  .option('-a, --all', l10n('CMD_UPDATE_OPT_ALL_MSG'))
   .description(l10n('CMD_UPDATE_DESC_MSG'))
   .action(async function (sids, cmd) {
     Promise.all(
-      db.subscriptions
-        .filter(s => sids.length === 0 || sids.includes(s.sid))
-        .map(s => {
-          return fetchThreads(s)
-            .then(newThreads => {
-              for (const nth of newThreads) {
-                if (!s.threads.map(th => th.title).includes(nth.title)) {
-                  console.log(l10n('CMD_UPDATE_UPDATED_MSG', { title: nth.title }))
-                  s.add(nth)
-                }
+      db.subscriptions.filter(s => cmd.all || sids.includes(s.sid)).map(s => {
+        return fetchThreads(s)
+          .then(newThreads => {
+            for (const nth of newThreads) {
+              if (!s.threads.map(th => th.title).includes(nth.title)) {
+                console.log(l10n('CMD_UPDATE_UPDATED_MSG', { title: nth.title }))
+                s.add(nth)
               }
-            })
-            .catch(error => {
-              console.error(error)
-            })
-        })
+            }
+          })
+          .catch(error => {
+            console.error(error)
+          })
+      })
     ).then(() => {
       db.sort()
       db.save()
     })
-  }).on('--help', function () {
+  })
+  .on('--help', function () {
     console.log(l10n('CMD_UPDATE_HELP_MSG'))
   })
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const { fetchThreads, fetchThreadsByKeyword } = require('./crawler')
 const { Subscription, Database } = require('./fakedb')
 const { getLocaleString: l10n } = require('./utils')
+const config = require('./config')
 
 const fs = require('fs')
 const program = require('commander')
@@ -206,6 +207,21 @@ program
   })
   .on('--help', function () {
     console.log(l10n('CMD_UPDATE_HELP_MSG'))
+  })
+
+program
+  .command('config <key> [value]')
+  .alias('cfg')
+  .description(l10n('CMD_CONFIG_DESC_MSG'))
+  .action(function (key, value) {
+    if (value === undefined) { // getter
+      console.log(config.get(key))
+    } else { // setter
+      config.set(key, value)
+    }
+  })
+  .on('--help', function () {
+    console.log(l10n('CMD_CONFIG_HELP_MSG'))
   })
 
 program.parse(process.argv)

--- a/locale/en.js
+++ b/locale/en.js
@@ -104,5 +104,7 @@ module.exports = {
   CMD_UPDATE_UPDATED_MSG: 'Updated: %title%',
   CMD_UPDATE_OPT_ALL_MSG: 'Update all subscribed {subscription}.',
   CMD_UPDATE_HELP_MSG: '',
+  CMD_CONFIG_DESC_MSG: '',
+  CMD_CONFIG_HELP_MSG: '',
   UNHANDLED_EP_PARSING_MSG: 'This should never print unless having bugs.\nPlease paste following information to https://github.com/FlandreDaisuki/dmhy-subscribe/issues.'
 }

--- a/locale/en.js
+++ b/locale/en.js
@@ -102,6 +102,7 @@ module.exports = {
   CMD_FIND_HELP_MSG: '',
   CMD_UPDATE_DESC_MSG: 'Just update {description}s without downloading.',
   CMD_UPDATE_UPDATED_MSG: 'Updated: %title%',
+  CMD_UPDATE_OPT_ALL_MSG: 'Update all subscribed {subscription}.',
   CMD_UPDATE_HELP_MSG: '',
   UNHANDLED_EP_PARSING_MSG: 'This should never print unless having bugs.\nPlease paste following information to https://github.com/FlandreDaisuki/dmhy-subscribe/issues.'
 }

--- a/locale/zh.js
+++ b/locale/zh.js
@@ -104,6 +104,7 @@ module.exports = {
   CMD_FIND_HELP_MSG: '',
   CMD_UPDATE_DESC_MSG: '只更新已訂閱的 {訂閱} 但不下載',
   CMD_UPDATE_UPDATED_MSG: '已更新: %title%',
+  CMD_UPDATE_OPT_ALL_MSG: '更新所有 {訂閱}',
   CMD_UPDATE_HELP_MSG: '',
   UNHANDLED_EP_PARSING_MSG: '這行只有在出現 bug 時會印出。\n請將下面印出的資訊貼上到 https://github.com/FlandreDaisuki/dmhy-subscribe/issues 回報'
 }

--- a/locale/zh.js
+++ b/locale/zh.js
@@ -106,5 +106,7 @@ module.exports = {
   CMD_UPDATE_UPDATED_MSG: '已更新: %title%',
   CMD_UPDATE_OPT_ALL_MSG: '更新所有 {訂閱}',
   CMD_UPDATE_HELP_MSG: '',
+  CMD_CONFIG_DESC_MSG: '',
+  CMD_CONFIG_HELP_MSG: '',
   UNHANDLED_EP_PARSING_MSG: '這行只有在出現 bug 時會印出。\n請將下面印出的資訊貼上到 https://github.com/FlandreDaisuki/dmhy-subscribe/issues 回報'
 }


### PR DESCRIPTION
RT

讓 `update` 有 `--all` 選項是為了和 `rm` 有一致性

而另一個 commit 是一個基本的 `config` 指令(HELP 和 DESC 都還沒弄)
用法大概就像:
```
$ dmhy config client
deluge
$ dmhy config client aria2c
$ dmhy config client
aria2c
```
我覺得還能改的地方還不少，像是驗證哪個選項可以設定為什麼值之類的