### PR TITLE
add webhook x-dmhy-token header

### DIFF
--- a/docs/webhook.md
+++ b/docs/webhook.md
@@ -1,1 +1,42 @@
 # webhook
+
+webhook 會對目標伺服器 `webhook-url` 發送一個 `POST` 請求，內容大致如下
+
+```json
+{
+  "title": "標題",
+  "link": "magnet 連結"
+}
+```
+
+## 驗證
+
+如果伺服器在收到任何請求就直接下載 `link` 中的檔案是很危險的，不過這可以透過 `x-dmhy-token` 這個 header 來驗證
+
+首先請先設定一個只有你知道的 token: `dmhy config webhook-token YOUR_TOKEN`
+
+接下來請在伺服器比較 `x-dmhy-token` 的內容與 `sha1("YOUR_TOKEN")` 是否相同，若不相同代表這個 request 可能是假的
+
+### Express 範例
+
+```js
+const app = require('express')()
+const crypto = require('crypto')
+
+const TOK = 'YOUR_TOKEN'
+const enc = crypto
+  .createHash('sha1')
+  .update(TOK)
+  .digest('hex')
+app.all('*', (req, res) => {
+  const tok = req.headers['x-dmhy-token']
+  if(tok === enc){
+    res.end()
+  }
+  else{
+    res.status(403).end()
+  }
+})
+
+app.listen(1234)
+```

--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,7 @@ const DEFAULTS = {
   'aria2-jsonrpc': 'http://localhost:6800/jsonrpc/',
   'destination': systemDownloadsFolder,
   'webhook-url': 'http://localhost/',
+  'webhook-token': 'DEFAULT_WEBHOOK_TOKEN',
 };
 const VALIDATORS = {
   'downloader': (downloader) => {

--- a/src/downloaders/webhook.js
+++ b/src/downloaders/webhook.js
@@ -1,12 +1,21 @@
 const axios = require('axios');
 const { print, l10n } = require('../..');
+const crypto = require('crypto');
 
 module.exports = (thread, config) => {
   print.debug('dmhy:downloaders:webhook:thread', thread);
   print.debug('dmhy:downloaders:webhook:config', config);
 
+  const tok = crypto
+    .createHash('sha1')
+    .update(config['webhook-token'])
+    .digest('hex');
   return axios
-    .post(config['webhook-url'], thread)
+    .post(config['webhook-url'], thread, {
+      headers: {
+        'x-dmhy-token': tok,
+      },
+    })
     .then(() => print.success(l10n('DOWNLOADER_DL_SUCCESS', { title: thread.title })))
     .catch(() => print.error(l10n('DOWNLOADER_DL_FAILED', { title: thread.title })));
 };


### PR DESCRIPTION
如題
會在使用 webhook 下載器時額外發送一個 header `x-dmhy-token`，它的值是 `sha1(config['webhook-token'])`

測試用 server:
```js
const app = require('express')()
const crypto = require('crypto')

const TOK='maple3142'
app.all('*', (req, res) => {
	const tok = req.headers['x-dmhy-token']
	const exp = crypto
		.createHash('sha1')
		.update(TOK)
		.digest('hex')
	if(tok === exp){
		res.end()
	}
	else{
		res.status(403).end()
	}
})

app.listen(1234)
```
結果:
![image](https://user-images.githubusercontent.com/9370547/40118253-fbc1e7d0-594b-11e8-84a9-37ed9a1a6945.png)
