### PR TITLE
Fix installation on MaxOS

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -90,7 +90,7 @@ const systemLocale = ((env) => {
     '0C04': 'zh_HK',
   };
 
-  const unix = () => (env.LC_ALL || env.LC_MESSAGES || env.LANG || env.LANGUAGE).replace(/[.].*$/, '');
+  const unix = () => (env.LC_ALL || env.LC_MESSAGES || env.LANG || env.LANGUAGE || '').replace(/[.].*$/, '');
 
 
   const windows = () => {
@@ -106,6 +106,7 @@ const systemLocale = ((env) => {
     freebsd: unix,
     linux: unix,
     sunos: unix,
+    darwin: unix,
     win32: windows,
   }[os.platform()]() || 'en_US';
 


### PR DESCRIPTION
修正在 MacOS 安裝失敗的問題

MacOS (darwin) 在原 110 行會因為沒有選到 funciotn 而錯誤
另外 因為 `LC_ALL, LC_MESSAGES, LANG || LANGUAGE` 都沒有值也會call undfined.replace 而錯誤

修正後可以直接安裝成功 (預設使用 `en_US`)，或加 `LC_ALL=XXX` 進行安裝