### PR TITLE
Fix typo and make setup script more friendly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ $ npm i -g dmhy-subscribe
 ```
 
 如果習慣使用 Docker 或 npm 無法正確安裝，也可以透過 [Docker](https://www.docker.com) 來執行本程式。
-* [Dokcer 安裝與使用教學](docs/docker.md)
+* [Docker 安裝與使用教學](docs/docker.md)
 
 ## Usage 使用方法
 

--- a/docker/setup.bash
+++ b/docker/setup.bash
@@ -1,13 +1,18 @@
 #!/bin/bash
 
-set -x
+set -ex
 
-mkdir -p data
-mkdir -p data/dmhy
-mkdir -p data/cron
-mkdir -p data/aria2
+mkdir -p data/dmhy data/cron data/aria2
 touch data/cron/cron.log
 cp config_examples/conf.example.json data/dmhy/config.json
 cp config_examples/cron.example      data/cron/dmhy-cron
 cp config_examples/aria2.conf        data/aria2/aria2.conf
+
+set +x
+
+echo
+echo "Setup completed. Please make sure that you have a 'dmhy-subscribe' docker image."
+echo "If not, you can"
+echo " - run \`docker pull wabilin/dmhy-subscribe && docker tag wabilin/dmhy-subscribe dmhy-subscribe\` to download it."
+echo " - or build it yourself with command: \`docker build . -t dmhy-subscribe\`."
 # docker build . -t dmhy-subscribe


### PR DESCRIPTION
- Fix typo in `docker/setup.bash` and `doc/docker.md`
- Add success messages to `docker/setup.bash`